### PR TITLE
prepare for 0.1.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_buf"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 description = "Generic buffering for serde"


### PR DESCRIPTION
## What's Changed
* Store owned strings as Box<str> and Box<[u8]> by @KodrAus in https://github.com/KodrAus/serde_buf/pull/1